### PR TITLE
Put init JS into separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ closeSpeed: 250               # close speed in ms
 closeOnClick: background      # background|anywhere|false
 closeOnEsc: true              # true|false on hitting Esc key
 root: body                    # where to append featherlights
+initTemplate: plugin://featherlight/js/featherlight.init.js
 ```
 
 You can also override any default setings from the page headers:
@@ -82,6 +83,28 @@ In Twig this could look like:
 ```
 
 More details can be found in the [Grav documentation for Media functionality](http://learn.getgrav.org/content/media).
+
+## Adding captions to the lightbox
+
+Image captions within the lightbox do not come out of the box with featherlight. But as the author described in his [wiki](https://github.com/noelboss/featherlight/wiki/Gallery:-showing-a-caption) it's quite easy to add.
+
+Per default we use a this script when initializing the plugin: [js/featherlight.init.js](js/featherlight.init.js). You can copy it to the "user" folder, change the initTemplate setting to `user://js/featherlight.init.js` and add a afterContent callback like this:
+
+    $(document).ready(function(){
+        $('a[rel="lightbox"]').{pluginName}({
+            openSpeed: {openSpeed},
+            closeSpeed: {closeSpeed},
+            closeOnClick: '{closeOnClick}',
+            root: '{root}',
+            afterContent: function() {
+                var caption = this.$currentTarget.find('img').attr('alt');
+                this.$instance.find('.caption').remove();
+                $('<div class="caption">').text(caption).appendTo(this.$instance.find('.featherlight-content'));
+            }
+        });
+    });
+
+The placeholders `{pluginName}`, `{openSpeed}`, `{closeSpeed}` and `{root}` will be replaced when processing this file.
 
 # Updating
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -91,3 +91,11 @@ form:
       label: Root
       default: 'body'
       help: Where to append featherlights
+
+    initTemplate:
+      type: text
+      size: medium
+      label: Init script
+      default: 'plugin://featherlight/js/featherlight.init.js'
+      placeholder: 'plugin://featherlight/js/featherlight.init.js'
+      help: Path to template file for JS init script

--- a/featherlight.php
+++ b/featherlight.php
@@ -90,9 +90,8 @@ class FeatherlightPlugin extends Plugin
     }
 
     protected function getInitJs($config) {
-        $pluginName = $config['gallery'] ? 'featherlightGallery' : 'featherlight';
-
         $asset = $this->grav['locator']->findResource($config['initTemplate'], false);
+
         $init = file_get_contents(ROOT_DIR . $asset);
 
         $init = str_replace(

--- a/featherlight.php
+++ b/featherlight.php
@@ -71,15 +71,8 @@ class FeatherlightPlugin extends Plugin
         $config = $this->config->get('plugins.featherlight');
 
         if ($config['gallery']) {
-            $init = "$(document).ready(function(){
-                $('a[rel=\"lightbox\"]').featherlightGallery({
-                    openSpeed: {$config['openSpeed']},
-                    closeSpeed: {$config['closeSpeed']},
-                    closeOnClick: '{$config['closeOnClick']}',
-                    root: '{$config['root']}'
-                });
-             });";
-             $this->grav['assets']
+            $init = $this->getInitJs($config);
+            $this->grav['assets']
                  ->addCss('plugin://featherlight/css/featherlight.min.css')
                  ->addCss('plugin://featherlight/css/featherlight.gallery.min.css')
                  ->add('jquery', 101)
@@ -87,19 +80,33 @@ class FeatherlightPlugin extends Plugin
                  ->addJs('plugin://featherlight/js/featherlight.gallery.min.js')
                  ->addInlineJs($init);
         } else {
-            $init = "$(document).ready(function() {
-                        $('a[rel=\"lightbox\"]').featherlight({
-                            openSpeed: {$config['openSpeed']},
-                            closeSpeed: {$config['closeSpeed']},
-                            closeOnClick: '{$config['closeOnClick']}',
-                            root: '{$config['root']}'
-                        });
-                     });";
+            $init = $this->getInitJs($config);
             $this->grav['assets']
                 ->addCss('plugin://featherlight/css/featherlight.min.css')
                 ->add('jquery', 101)
                 ->addJs('plugin://featherlight/js/featherlight.min.js')
                 ->addInlineJs($init);
         }
+    }
+
+    protected function getInitJs($config) {
+        $pluginName = $config['gallery'] ? 'featherlightGallery' : 'featherlight';
+
+        $asset = $this->grav['locator']->findResource($config['initTemplate'], false);
+        $init = file_get_contents(ROOT_DIR . $asset);
+
+        $init = str_replace(
+            array('{pluginName}', '{openSpeed}', '{closeSpeed}', '{closeOnClick}', '{root}'),
+            array(
+                $config['gallery'] ? 'featherlightGallery' : 'featherlight',
+                $config['openSpeed'],
+                $config['closeSpeed'],
+                $config['closeOnClick'],
+                $config['root']
+            ),
+            $init
+        );
+
+        return $init;
     }
 }

--- a/featherlight.yaml
+++ b/featherlight.yaml
@@ -6,3 +6,4 @@ closeSpeed: 250               # close speed in ms
 closeOnClick: background      # background|anywhere|false
 closeOnEsc: true              # true|false on hitting Esc key
 root: body                    # where to append featherlights
+initTemplate: plugin://featherlight/js/featherlight.init.js

--- a/js/featherlight.init.js
+++ b/js/featherlight.init.js
@@ -1,0 +1,8 @@
+$(document).ready(function(){
+    $('a[rel="lightbox"]').{pluginName}({
+        openSpeed: {openSpeed},
+        closeSpeed: {closeSpeed},
+        closeOnClick: '{closeOnClick}',
+        root: '{root}'
+    });
+});


### PR DESCRIPTION
This allows to override the default init script, e.g. to add an image caption to the lightbox.
